### PR TITLE
Update \version statement to minimum required lilypond version

### DIFF
--- a/package.ily
+++ b/package.ily
@@ -32,7 +32,7 @@
   Main functionality for font selection.
 %}
 
-\version "2.19.12"
+\version "2.19.22"
 
 \include "__init__.ily"
 


### PR DESCRIPTION
An addition to my last pull request. That way lilypond should give a more helpful error message if using a now unsupported version. (Although pretty much anybody running into this would probably know what's going on, but still.)